### PR TITLE
TGP-1579:Removed the verify header

### DIFF
--- a/src/test/scala/uk/gov/hmrc/test/ui/pages/ProfileSetup/NIRMSNumberPage.scala
+++ b/src/test/scala/uk/gov/hmrc/test/ui/pages/ProfileSetup/NIRMSNumberPage.scala
@@ -24,8 +24,4 @@ object NIRMSNumberPage extends Page {
   override def title(args: String*): String = "Northern Ireland Retail Movement Scheme number"
   override def h1(args: String*): String    = "What is your NIRMS number?"
 
-  override def verifyHeader(h1: String): this.type = {
-    findBy(By.className("govuk-label--l")).getText.shouldEqual(h1)
-    this
-  }
 }


### PR DESCRIPTION
Removed the verify header here as it's been changed to govuk-heading-l and handled in base page anyway.