### PR TITLE
TGP-1694: Handle "category" on Goods record page

### DIFF
--- a/src/test/resources/features/Local/04_UpdateRecords.feature
+++ b/src/test/resources/features/Local/04_UpdateRecords.feature
@@ -19,13 +19,6 @@ Feature: Trader Goods Profile - View or Update record journey
     And I select continue
     Then I should be on the 'Goods record' page
     When I click the Goods record Goods Description change link
-    Then I should be on the Goods record Goods Description warning page
-    And I select continue
-    Then Error message 'Select if you want to change the goods description' should be displayed
-    When I select the back link
-    Then I should be on the Goods record Goods Description warning page
-    And I select Yes for the boolean question
-    When I select continue
     Then I should be on the 'Goods description' update page
     When I enter long text in the Goods description text area
     Then Error message 'The goods description must be 512 characters or less' should be displayed

--- a/src/test/resources/features/TraderGoodsProfile/04_UpdateRecords.feature
+++ b/src/test/resources/features/TraderGoodsProfile/04_UpdateRecords.feature
@@ -18,9 +18,6 @@ Feature: Trader Goods Profile - View or Update record journey
     And I select continue
     Then I should be on the 'Goods record' page
     When I click the Goods record Goods Description change link
-    Then I should be on the Goods record Goods Description warning page
-    And I select Yes for the boolean question
-    When I select continue
     Then I should be on the 'Goods description' update page
     And I select continue
     Then I should be on the 'Goods description' CYA page


### PR DESCRIPTION
Updating journey tests as part of [https://jira.tools.tax.service.gov.uk/browse/TGP-1694](url) 
Scenario 6: On goods record page. When record is categorised as 1,2 or standard and we click the change link on goods description row, we skip the warning page and go straight to the goods description input page.